### PR TITLE
Added support for legacy hierarchical tags in new goodreads page

### DIFF
--- a/goodreads/CHANGELOG.md
+++ b/goodreads/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Goodreads Change Log
 
+## [1.7.1] - 2022-10-09
+### Changed
+- Added support for legacy hierarchical tags in new goodreads page (@NeyNey)
+
 ## [1.7.0] - 2022-09-24
 _All kiwidude plugins updated/migrated to: https://github.com/kiwidude68/calibre_plugins_
 ### Added

--- a/goodreads/__init__.py
+++ b/goodreads/__init__.py
@@ -30,7 +30,7 @@ class Goodreads(Source):
     name = 'Goodreads'
     description = 'Downloads metadata and covers from Goodreads'
     author = 'Grant Drake'
-    version = (1, 7, 0)
+    version = (1, 7, 1)
     minimum_calibre_version = (2, 0, 0)
 
     capabilities = frozenset(['identify', 'cover'])

--- a/goodreads/worker.py
+++ b/goodreads/worker.py
@@ -727,12 +727,22 @@ class Worker(Thread): # Get details
         calibre_tag_lookup = cfg.plugin_prefs[cfg.STORE_NAME][cfg.KEY_GENRE_MAPPINGS]
         calibre_tag_map = dict((k.lower(),v) for (k,v) in calibre_tag_lookup.items())
         tags_to_add = list()
+        # self.log.info("Tags found in gd:", genre_tags)
         for genre_tag in genre_tags:
+            # flatten tag (sometimes tags aren't flat, beats me why, guess goodreads still wip) 
+            # tag should be flattened if it contains ' > '
+            if ' > ' in genre_tag:
+                # self.log.info("Tag before flattening:", genre_tag)
+                # last element is the tag visible on gd page
+                genre_tag = genre_tag.split(' > ').pop()
+                # self.log.info("Tag after flattening:", genre_tag)
             tags = calibre_tag_map.get(genre_tag.lower(), None)
             if tags:
                 for tag in tags:
                     if tag not in tags_to_add:
                         tags_to_add.append(tag)
+        
+        # self.log.info("Tags added:", tags_to_add)
         return list(tags_to_add)
 
     def _convert_date_text(self, date_text):


### PR DESCRIPTION
The behaviour of gd is not consistent, for the same book once I got flat tags, other time not.
Plugin downloading different tags for the same book was what got into investigating why.

Part of the logs, where I got not flat tags:
Tags found in gd: ['Romance > Paranormal Romance', 'Paranormal > Vampires', 'Fantasy > Paranormal', 'Romance', 'Fantasy', 'Holiday > Christmas', 'Novella', 'Fantasy > Urban Fantasy', 'Short Stories', 'Contemporary']
Tag before flattening: Romance > Paranormal Romance
Tag after flattening: Paranormal Romance
Tag before flattening: Paranormal > Vampires
Tag after flattening: Vampires
Tag before flattening: Fantasy > Paranormal
Tag after flattening: Paranormal
Tag before flattening: Holiday > Christmas
Tag after flattening: Christmas
Tag before flattening: Fantasy > Urban Fantasy
Tag after flattening: Urban Fantasy
Tags added: ['Paranormal', 'Romance', 'Vampires', 'Fantasy', 'Urban Fantasy', 'Anthologies', 'Contemporary']