### PR TITLE
Make commons work simply by dropping in

### DIFF
--- a/common/common_dialogs.py
+++ b/common/common_dialogs.py
@@ -26,7 +26,7 @@ except NameError:
 
 from calibre.gui2 import gprefs, info_dialog, Application
 from calibre.gui2.keyboard import ShortcutConfig
-from common_icons import get_icon
+exec("from " + __name__.rpartition('.')[0] + ".common_icons import get_icon")
 
 
 # ----------------------------------------------

--- a/common/common_menus.py
+++ b/common/common_menus.py
@@ -8,7 +8,7 @@ __copyright__ = '2022, Grant Drake'
 
 from calibre.gui2.actions import menu_action_unique_name
 from calibre.constants import numeric_version as calibre_version
-from common_icons import get_icon
+exec("from " + __name__.rpartition('.')[0] + ".common_icons import get_icon")
 
 # ----------------------------------------------
 #          Global resources / state

--- a/common/common_widgets.py
+++ b/common/common_widgets.py
@@ -23,7 +23,8 @@ except NameError:
 from calibre.gui2 import error_dialog, UNDEFINED_QDATETIME
 from calibre.utils.date import now, format_date, UNDEFINED_DATE
 
-from common_icons import get_pixmap
+exec("from " + __name__.rpartition('.')[0] + ".common_icons import get_pixmap")
+
 
 # get_date_format
 #


### PR DESCRIPTION
No need to build plugins.

Just copy common_*.py into each plugin directory and it works.