### PR TITLE
Goodreads - Handle contributors with no name

### DIFF
--- a/goodreads/__init__.py
+++ b/goodreads/__init__.py
@@ -30,7 +30,7 @@ class Goodreads(Source):
     name = 'Goodreads'
     description = 'Downloads metadata and covers from Goodreads'
     author = 'Grant Drake'
-    version = (1, 7, 2)
+    version = (1, 7, 3)
     minimum_calibre_version = (2, 0, 0)
 
     capabilities = frozenset(['identify', 'cover'])

--- a/goodreads/worker.py
+++ b/goodreads/worker.py
@@ -415,6 +415,9 @@ class Worker(Thread): # Get details
         get_all_authors = cfg.plugin_prefs[cfg.STORE_NAME][cfg.KEY_GET_ALL_AUTHORS]
         authors = []
         for contributor_json in contributors_list_json:
+            if (contributor_json.get("name") is None):
+                continue
+
             author_name = contributor_json["name"]
             self.log.info('parse_authors - author: %s'%author_name)
             if get_all_authors:


### PR DESCRIPTION
If you try to load this book, https://www.goodreads.com/book/show/11711626, you'll get this contributor metadata:

```
  "Contributor:kca://author/amzn1.gr.author.v1.AHEnyjFTx2DoYrWWllqBLw": {
    "id": "kca://author/amzn1.gr.author.v1.AHEnyjFTx2DoYrWWllqBLw",
    "__typename": "Contributor",
    "works": {
      "__typename": "ContributorWorksConnection",
      "totalCount": 5
    }
  },
```

This doesn't have a `name` key, so `author_name = contributor_json["name"]` throws.

I worked around it by ensuring the `name` key exists on the json object before trying to use it. Tested it locally and all is well.