### PR TITLE
Count Pages : Strips html before using backstop page count.

### DIFF
--- a/count_pages/statistics.py
+++ b/count_pages/statistics.py
@@ -193,6 +193,12 @@ def _get_page_count_accurate(iterator):
     # As a backstop count the characters using the "fast count" algorithm
     # and use that number instead
     fast_count = int(len(epub_html) / 2400) + 1
+    if (fast_count > count) :
+        # Before we are use the backstop, we should strip out the html
+        # otherwise our count could be vastly over-stated.
+        epub_html = _read_epub_contents(iterator, strip_html=True)
+        fast_count = int(len(epub_html) / 2400) + 1
+
     print('\tEstimated accurate page count')
     print('\t  Lines:', len(lines), ' Divs:', num_divs, ' Paras:', num_paras)
     print('\t  Accurate count:', count, ' Fast count:', fast_count)


### PR DESCRIPTION
The Paragraphs (APNX accurate) algorithm has a back stop to use a "fast count" algorithm which is based on the length of the text.  However this was based on the full text including the html formatting.

This can lead to the fast count algorithm producing page counts which are inflated and sometimes **greatly** inflated. For example, one book has a fast count of 2570 for a book with an accurate count of 389 pages.

So we now strip out the html before calculating the fast count. 
The fast count on the example book becomes 252 which is lower than the accurate count and hence ignored.
