### PR TITLE
Goodreads - Add randomised chrome user agent

### DIFF
--- a/goodreads/__init__.py
+++ b/goodreads/__init__.py
@@ -45,6 +45,12 @@ class Goodreads(Source):
     BASE_URL = 'https://www.goodreads.com'
     MAX_EDITIONS = 5
 
+    @property
+    def user_agent(self):
+        from calibre.utils.random_ua import random_common_chrome_user_agent
+        return random_common_chrome_user_agent()
+
+
     def config_widget(self):
         '''
         Overriding the default configuration screen for our own custom configuration


### PR DESCRIPTION
As mentioned in issue #25, one possible fix is to force the parser to only use Chrome user agent. I've implemented such a fix that uses only Chrome user agent but randomised ones.

Calibre itself has an utility function that returns a randomised common Chrome user agent from its self-maintained list of user agents. So what I've did was simply overwriting [Calibre's metadata plugin implementation of randomising user agent](https://github.com/kovidgoyal/calibre/blob/master/src/calibre/ebooks/metadata/sources/base.py#L283) to use the previous mentioned utility function.