### PR TITLE
Switch sync from using unsupported API to HTML

### DIFF
--- a/goodreads_sync/dialogs.py
+++ b/goodreads_sync/dialogs.py
@@ -417,7 +417,11 @@ class ChooseShelvesToSyncDialog(SizePersistedDialog):
                 self.selected_shelves.append(shelf)
         
         self.plugin_action.progressbar_show(1)
-        self.goodreads_shelf_books = self.grhttp.get_goodreads_books_on_shelves(self.user_name, self.selected_shelves)
+        use_xml_api = False # Not maintained and does not include date read
+        if use_xml_api:
+            self.goodreads_shelf_books = self.grhttp.get_goodreads_books_on_shelves_xml(self.user_name, self.selected_shelves)
+        else:
+            self.goodreads_shelf_books = self.grhttp.get_goodreads_books_on_shelves_html(self.user_name, self.selected_shelves)
         self.plugin_action.progressbar_hide()
         self.accept()
 

--- a/goodreads_sync/dialogs.py
+++ b/goodreads_sync/dialogs.py
@@ -415,13 +415,9 @@ class ChooseShelvesToSyncDialog(SizePersistedDialog):
         for shelf in self.shelves:
             if shelf['name'] in self.selected_shelf_names:
                 self.selected_shelves.append(shelf)
-        
+
         self.plugin_action.progressbar_show(1)
-        use_xml_api = False # Not maintained and does not include date read
-        if use_xml_api:
-            self.goodreads_shelf_books = self.grhttp.get_goodreads_books_on_shelves_xml(self.user_name, self.selected_shelves)
-        else:
-            self.goodreads_shelf_books = self.grhttp.get_goodreads_books_on_shelves_html(self.user_name, self.selected_shelves)
+        self.goodreads_shelf_books = self.grhttp.get_goodreads_books_on_shelves(self.user_name, self.selected_shelves)
         self.plugin_action.progressbar_hide()
         self.accept()
 


### PR DESCRIPTION
The fast XML based API no longer has read dates for newly read books. It is possible to get that data by scraping the normal HTML pages but it is slower and probably less reliable. But it works.

I've left all the old code in the source controlled by a flag in ChooseShelvesToSyncDialog._accept_clicked

Not sure this is the way to go, but something will eventually be needed.