### PR TITLE
QUality Check - Improve corrupt zip check

### DIFF
--- a/quality_check/check_epub.py
+++ b/quality_check/check_epub.py
@@ -26,7 +26,7 @@ from calibre.ebooks.conversion.preprocess import HTMLPreProcessor
 from calibre.ebooks.metadata.epub import Encryption
 from calibre.ebooks.oeb.base import XPath
 from calibre.ebooks.oeb.parse_utils import RECOVER_PARSER, NotHTML, parse_html
-from calibre.utils.zipfile import ZipFile
+from calibre.utils.zipfile import ZipFile, BadZipfile
 
 from calibre_plugins.quality_check.check_base import BaseCheck
 from calibre_plugins.quality_check.dialogs import SearchEpubDialog
@@ -981,9 +981,13 @@ class EpubCheck(BaseCheck):
                 return False
             try:
                 with ZipFile(path_to_book, 'r') as zf:
+                    for e in zf.namelist():
+                        zf.read(e)
                     return False
 
             except InvalidEpub:
+                return True
+            except BadZipfile:
                 return True
             except:
                 return True


### PR DESCRIPTION
Improve the corrupted zip check by reading all files inside the ePub.

In some case, the ZIP file is valid and don't raise error when open it with the ZipFile class, but somes files inside are not valid and can't be read/uncompress.