### PR TITLE
Quality Check - fix wrong match in corrupt zip check

### DIFF
--- a/quality_check/check_epub.py
+++ b/quality_check/check_epub.py
@@ -981,7 +981,11 @@ class EpubCheck(BaseCheck):
                 return False
             try:
                 with ZipFile(path_to_book, 'r') as zf:
-                    for e in zf.namelist():
+                    for e in zf.infolist():
+                        if e.filename.endswith('/'): #file represent a folder
+                            continue
+                        if e.file_size == 0: #file is empty (cannot be read)
+                            continue
                         zf.read(e)
                     return False
 


### PR DESCRIPTION
Fix 2 false-positive match in corrupt zip check

1. Some ZIP has entry than represent a folder.
2. Some empty files raise a error when you try to read it.