### PR TITLE
fix(Goodreads Sync): Use SSL Context to init HTTPSConnection in Py3.12 compliant way

### DIFF
--- a/goodreads_sync/CHANGELOG.md
+++ b/goodreads_sync/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Goodreads Sync Change Log
 
+## [1.16.6] - 2024-05-15
+### Fixed
+- Use `SSLContext` object to pass `key_file` and `cert_file` to `HTTPSConnection` constructor making the plugin Python 3.12 capable.
+
 ## [1.16.5] - 2024-03-17
 ### Updated
 - Spanish translation

--- a/goodreads_sync/__init__.py
+++ b/goodreads_sync/__init__.py
@@ -20,7 +20,7 @@ class ActionGoodreadsSync(InterfaceActionBase):
     description             = 'Sync from Calibre with the shelves of your GoodReads.com account'
     supported_platforms     = ['windows', 'osx', 'linux']
     author                  = 'Grant Drake'
-    version                 = (1, 16, 5)
+    version                 = (1, 16, 6)
     minimum_calibre_version = (2, 0, 0)
 
     #: This field defines the GUI plugin class that contains all the code

--- a/goodreads_sync/httplib2/__init__.py
+++ b/goodreads_sync/httplib2/__init__.py
@@ -996,9 +996,9 @@ class HTTPSConnectionWithTimeout(httplib.HTTPSConnection):
                  strict=None, timeout=None, proxy_info=None,
                  ca_certs=None, disable_ssl_certificate_validation=False,
                  ssl_version=None):
-        httplib.HTTPSConnection.__init__(self, host, port=port,
-                                         key_file=key_file,
-                                         cert_file=cert_file)
+        context = ssl.create_default_context()
+        context.load_cert_chain(certfile=cert_file, keyfile=key_file)
+        httplib.HTTPSConnection.__init__(self, host, port=port, context=context)
         self.timeout = timeout
         self.proxy_info = proxy_info
         if ca_certs is None:
@@ -1181,12 +1181,10 @@ class AppEngineHttpsConnection(httplib.HTTPSConnection):
                  strict=None, timeout=None, proxy_info=None, ca_certs=None,
                  disable_ssl_certificate_validation=False,
                  ssl_version=None):
-        httplib.HTTPSConnection.__init__(self, host, port=port,
-                                         key_file=key_file,
-                                         cert_file=cert_file,
-                                         timeout=timeout)
-        self._fetch = _new_fixed_fetch(
-                not disable_ssl_certificate_validation)
+        context = ssl.create_default_context()
+        context.load_cert_chain(certfile=cert_file, keyfile=key_file)
+        httplib.HTTPSConnection.__init__(self, host, port=port, context=context, timeout=timeout)
+        self._fetch = _new_fixed_fetch(not disable_ssl_certificate_validation)
 
 # Use a different connection object for Google App Engine
 try:


### PR DESCRIPTION
In Python 3.6, the two parameters `key_file` and `cert_file` of [`http.client.HTTPSConnection`](https://docs.python.org/3.11/library/http.client.html#http.client.HTTPSConnection) were deprecated in favour of an [`ssl.SSLContext`](https://docs.python.org/3.11/library/ssl.html#ssl.SSLContext) parameter. Now in Python 3.12 the deprecated parameters were removed completely.
This PR refactors the usage of `key_file` and `cert_file` so that is compliant with Python 3.12 while being backwards compatible to older Python versions.

I added the resulting error message in #71 

Note: I am working on Linux and therefore cannot execute the build.cmd - this would need to be done by someone else (The CI pipeline would the best place for this imho...)