### PR TITLE
fix: don't use gui as parent for menu

### DIFF
--- a/clipboard_search/action.py
+++ b/clipboard_search/action.py
@@ -37,7 +37,7 @@ class ClipboardSearchAction(InterfaceAction):
 
     def genesis(self):
         self.default_search_is_exact = False
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
 
         # Read the plugin icons and store for potential sharing with the config widget
         icon_resources = self.load_resources(PLUGIN_ICONS)

--- a/count_pages/action.py
+++ b/count_pages/action.py
@@ -40,7 +40,7 @@ class CountPagesAction(InterfaceAction):
 
     def genesis(self):
         self.is_library_selected = True
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
         # Read the plugin icons and store for potential sharing with the config widget
         icon_resources = self.load_resources(cfg.PLUGIN_ICONS)
         set_plugin_icon_resources(self.name, icon_resources)

--- a/cover_url/action.py
+++ b/cover_url/action.py
@@ -41,7 +41,7 @@ class CoverUrlAction(InterfaceAction):
         set_plugin_icon_resources(self.name, icon_resources)
 
         # Assign our menu to this action and an icon
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
         self.qaction.setMenu(self.menu)
         self.qaction.setIcon(get_icon(PLUGIN_ICONS[0]))
         self.qaction.triggered.connect(self.get_covers)

--- a/favourites_menu/action.py
+++ b/favourites_menu/action.py
@@ -71,7 +71,7 @@ class FavouritesMenuAction(InterfaceAction):
     action_type = 'current'
 
     def genesis(self):
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
         self.menu.aboutToShow.connect(self._about_to_show_menu)
 
         # Read the plugin icons and store for potential sharing with the config widget

--- a/find_duplicates/action.py
+++ b/find_duplicates/action.py
@@ -47,7 +47,7 @@ class FindDuplicatesAction(InterfaceAction):
     action_type = 'current'
 
     def genesis(self):
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
 
         # Read the plugin icons and store for potential sharing with the config widget
         icon_resources = self.load_resources(PLUGIN_ICONS)

--- a/goodreads_sync/action.py
+++ b/goodreads_sync/action.py
@@ -56,7 +56,7 @@ class GoodreadsSyncAction(InterfaceAction):
     pb = None
 
     def genesis(self):
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
 
         # Read the plugin icons and store for potential sharing with the config widget
         icon_resources = self.load_resources(PLUGIN_ICONS)

--- a/open_with/action.py
+++ b/open_with/action.py
@@ -38,7 +38,7 @@ class OpenWithAction(InterfaceAction):
     def genesis(self):
         self.is_library_selected = True
         self.menus_by_format = {}
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
 
         # Read the plugin icons and store for potential sharing with the config widget
         icon_names = ['images/'+i for i in cfg.get_default_icon_names()]

--- a/quality_check/action.py
+++ b/quality_check/action.py
@@ -40,7 +40,7 @@ class QualityCheckAction(InterfaceAction):
     action_type = 'current'
 
     def genesis(self):
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
         self.last_menu_key = None
         self.last_menu_cat = None
 

--- a/quick_preferences/action.py
+++ b/quick_preferences/action.py
@@ -39,7 +39,7 @@ class QuickPreferencesAction(InterfaceAction):
                 (_('Create new record for each duplicate format'), 'new record')]
 
     def genesis(self):
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
 
         # Read the plugin icons and store for potential sharing with the config widget
         icon_resources = self.load_resources(PLUGIN_ICONS)
@@ -102,7 +102,7 @@ class QuickPreferencesAction(InterfaceAction):
                         is_checked=False, shortcut_name='Toggle Add Option: Automerge added books if exist',
                         triggered=partial(self.switch_checkbox_preference, 'add_formats_to_existing'))
         self.add_formats_to_existing.setVisible(cos[cfg.OPT_ADD_FORMAT_EXISTING][0])
-        self.automerge_sub_menu = QMenu(_('Automerge type'), self.gui)
+        self.automerge_sub_menu = QMenu(_('Automerge type'), m)
         if cos[cfg.OPT_ADD_FORMAT_EXISTING][0]:
             m.addMenu(self.automerge_sub_menu)
         self.automerge_menus = []

--- a/ratings/action.py
+++ b/ratings/action.py
@@ -39,7 +39,7 @@ class RatingsAction(InterfaceAction):
         # Read the plugin icons and store for potential sharing with the config widget
         icon_resources = self.load_resources(PLUGIN_ICONS)
         set_plugin_icon_resources(self.name, icon_resources)
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
 
         # Assign our menu to this action and an icon
         self.qaction.setMenu(self.menu)

--- a/reading_list/action.py
+++ b/reading_list/action.py
@@ -63,7 +63,7 @@ class ReadingListAction(InterfaceAction):
     def genesis(self):
         self.menus_lock = threading.RLock()
         self.sync_lock = threading.RLock()
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
 
         # Read the plugin icons and store for potential sharing with the config widget
         icon_resources = self.load_resources(PLUGIN_ICONS)

--- a/resize_cover/action.py
+++ b/resize_cover/action.py
@@ -32,7 +32,7 @@ class ResizeCoverAction(InterfaceAction):
     action_type = 'current'
 
     def genesis(self):
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
         self.old_actions_unique_map = {}
         self.default_size_data = None
 

--- a/search_the_internet/action.py
+++ b/search_the_internet/action.py
@@ -48,7 +48,7 @@ class SearchTheInternetAction(InterfaceAction):
     action_type = 'current'
 
     def genesis(self):
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
 
         # Read the plugin icons and store for potential sharing with the config widget
         icon_names = ['images/'+i for i in cfg.get_default_icon_names()]

--- a/user_category/action.py
+++ b/user_category/action.py
@@ -43,7 +43,7 @@ class UserCategoryAction(InterfaceAction):
                                        'publishers':_('publishers'),'tags':_('tags') }
         self.old_actions_unique_map = {}
         self.sub_menus_evaluated = []
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
 
         # Read the plugin icons and store for potential sharing with the config widget
         icon_resources = self.load_resources(PLUGIN_ICONS)

--- a/view_manager/action.py
+++ b/view_manager/action.py
@@ -40,7 +40,7 @@ class ViewManagerAction(InterfaceAction):
     action_type = 'current'
 
     def genesis(self):
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
 
         # Read the plugin icons and store for potential sharing with the config widget
         icon_resources = self.load_resources(PLUGIN_ICONS)

--- a/walk_search_history/action.py
+++ b/walk_search_history/action.py
@@ -39,7 +39,7 @@ class WalkSearchHistoryAction(InterfaceAction):
         self.is_navigating_history = False
         self.last_search_text = ''
         self.library_history = dict()
-        self.menu = QMenu(self.gui)
+        self.menu = QMenu()
 
         # Read the plugin icons and store for potential sharing with the config widget
         icon_resources = self.load_resources(PLUGIN_ICONS)


### PR DESCRIPTION
fix: don't use gui as parent for menu, raise a warning on linux