### PR TITLE
Changed goodreads plugin to use XML endpoint to retrieve metadata

### DIFF
--- a/goodreads/CHANGELOG.md
+++ b/goodreads/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Goodreads Change Log
 
+## [1.9.1] - 2026-06-14
+### Fixed
+- Retrieve book detail pages through the `.xml` URL variant, which returns the
+  full metadata page while the extensionless URL is blocked by AWS WAF.
+
 ## [1.9.0] - 2026-05-17
 ### Fixed
 - Bypass AWS WAF protection preventing search results from being returned (not publicly released)

--- a/goodreads/__init__.py
+++ b/goodreads/__init__.py
@@ -36,7 +36,7 @@ class Goodreads(Source):
     name = 'Goodreads'
     description = 'Downloads metadata and covers from Goodreads'
     author = 'Grant Drake'
-    version = (1, 9, 0)
+    version = (1, 9, 1)
     minimum_calibre_version = (2, 0, 0)
 
     capabilities = frozenset(['identify', 'cover'])
@@ -88,6 +88,11 @@ class Goodreads(Source):
         if match:
             return (self.ID_NAME, match.groups(0)[0])
         return None
+
+    def get_details_url(self, goodreads_id):
+        # The extensionless book page is protected by AWS WAF. Goodreads still
+        # serves the same Next.js page, including __NEXT_DATA__, at this URL.
+        return '%s/book/show/%s.xml' % (self.BASE_URL, goodreads_id)
         
     def create_query(self, title=None, authors=None):
         tokens = []
@@ -220,7 +225,7 @@ class Goodreads(Source):
         br = self.browser
 
         if goodreads_id:
-            matches.append('%s/book/show/%s' % (Goodreads.BASE_URL, goodreads_id))
+            matches.append(self.get_details_url(goodreads_id))
         else:
             # Can't find a valid id, so search using the title and authors.
             log.info('No identifiers, searching for title/author')
@@ -367,7 +372,7 @@ class Goodreads(Source):
             authors = [a.strip() for a in author.split(',')]
             if ismatch(title, authors):
                 goodreads_id = work_node.findtext('best_book/id')
-                result_url = Goodreads.BASE_URL + '/book/show/%s' % goodreads_id
+                result_url = self.get_details_url(goodreads_id)
                 log.debug("_parse_search_results: Title: %s, Author: %s, URL: %s" % (title, author, result_url))
                 matches.append(result_url)
 


### PR DESCRIPTION
### Issue

#171 - No website data found for Goodreads plugin

### Description

Fix Goodreads metadata and cover downloads by fetching book detail pages through `/book/show/<id>.xml`, which returns the full Next.js page and `__NEXT_DATA__` metadata while the extensionless URL is blocked by AWS WAF. 

Both identifier-based and title/author search results now use this endpoint, and the plugin version is bumped to 1.9.1.

Tested on local Calibre instance using `.build.cmd` and importing plugin from file.